### PR TITLE
Pinning the host container to debian:11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid
+FROM debian:11
 EXPOSE 2222
 
 # Install all needed packages


### PR DESCRIPTION
The QEMU host was previously on debian:sid (unstable) as some of the packages required were not in stable apt sources yet.
I tested on the latest version of 11 and it works fine now, so pinning to get us back on a more stable version of Debian.

This should also trigger dockerhub to update the image.
Currently the version on dockerhub is ancient, and will bump the risc-v guest OS image from 
`Linux debian 5.10.0-1-riscv64 #1 SMP Debian 5.10.4-1 (2020-12-31) riscv64`
to
`Linux debian 5.15.0-2-riscv64 #1 SMP Debian 5.15.5-1 (2021-11-26) riscv64`