### PR TITLE
Fix build process of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ WORKDIR "/root"
 RUN wget https://gitlab.com/api/v4/projects/giomasce%2Fdqib/jobs/artifacts/master/download?job=convert_riscv64-virt -O artifacts.zip && \
 unzip artifacts.zip && rm artifacts.zip
 
-CMD qemu-system-riscv64 -smp 2 -m 2G -cpu rv64 -nographic -machine virt -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf -device virtio-blk-device,drive=hd -drive file=artifacts/image.qcow2,if=none,id=hd -device virtio-net-device,netdev=net -netdev user,id=net,hostfwd=tcp::2222-:22 -object rng-random,filename=/dev/urandom,id=rng -device virtio-rng-device,rng=rng -append "root=LABEL=rootfs console=ttyS0"
+CMD qemu-system-riscv64 -smp 2 -m 2G -cpu rv64 -nographic -machine virt -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf -device virtio-blk-device,drive=hd -drive file=dqib_riscv64-virt/image.qcow2,if=none,id=hd -device virtio-net-device,netdev=net -netdev user,id=net,hostfwd=tcp::2222-:22 -object rng-random,filename=/dev/urandom,id=rng -device virtio-rng-device,rng=rng -append "root=LABEL=rootfs console=ttyS0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ EXPOSE 2222
 
 # Install all needed packages
 RUN apt-get update && \
-apt-get install -y --no-install-recommends ca-certificates git wget build-essential ninja-build libglib2.0-dev libpixman-1-dev u-boot-qemu unzip && \
+apt-get install -y --no-install-recommends ca-certificates git wget build-essential ninja-build libglib2.0-dev libpixman-1-dev u-boot-qemu unzip libslirp-dev && \
 # clean up the temp files
 apt-get autoremove -y && \
 apt-get clean && \


### PR DESCRIPTION
Hi @DavidBurela, 
thanks for making the Dockerfile and the docker image. 

Unfortunately I couldn't run a container off of the image itself since I'm on ARM (Macbook M1) but I wanted to build it on my machine and I couldn't. 
There were 2 issues that I hope you can merge (not ARM related):

- qemu expects `libslirp` to be installed so `-netdev user` can work. 
- dqib `artifacts` folder doesn't exist anymore and it's called `dqib_riscv64-virt`

With these changes the build process went smooth and I can play with risc-v. 

I have also built the ARM image here if you're interested - https://hub.docker.com/r/krydos/riscv-emulator-on-arm

Not sure if there is a simple way to somehow add it to your DockerHub but if you know how to do it please let me know. 
