### PR TITLE
FIX: including `python3-venv` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ EXPOSE 2222
 
 # Install all needed packages
 RUN apt-get update && \
-apt-get install -y --no-install-recommends ca-certificates git wget build-essential ninja-build libglib2.0-dev libpixman-1-dev u-boot-qemu unzip libslirp-dev && \
+apt-get install -y --no-install-recommends ca-certificates git wget build-essential ninja-build libglib2.0-dev libpixman-1-dev u-boot-qemu unzip libslirp-dev python3-venv && \
 # clean up the temp files
 apt-get autoremove -y && \
 apt-get clean && \


### PR DESCRIPTION
It seems to be required now, else QEMU compilation fails with error:
```
196.9 python determined to be '/usr/bin/python3'
196.9 python version: Python 3.9.2
196.9
196.9 *** Ouch! ***
196.9
196.9 Python's ensurepip module is not found.
196.9 It's normally part of the Python standard library, maybe your distribution packages it separately?
196.9 Either install ensurepip, or alleviate the need for it in the first place by installing pip and setuptools for '/usr/bin/python3'.
196.9 (Hint: Debian puts ensurepip in its python3-venv package.)
196.9
196.9
196.9
196.9 ERROR: python venv creation failed
196.9
```